### PR TITLE
Fix red-black tree dependency and adjust algorithms

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module leetcode
 
 go 1.21
-
-require github.com/emirpasic/gods v1.18.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
-github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=

--- a/problems/2817_Minimum_Absolute_Difference_Between_Elements_With_Constraint/solution.go
+++ b/problems/2817_Minimum_Absolute_Difference_Between_Elements_With_Constraint/solution.go
@@ -1,23 +1,32 @@
 package _817_Minimum_Absolute_Difference_Between_Elements_With_Constraint
 
-// 我們從i = x開始陸續把 i - x插入sorted set
-// 然後開始找他的upper bound & lower bound
-// 這題的重點在于golang中如何產生有序集合
-// 此時要記得在golang中 sorted set 可以用rbt進行
-import "github.com/emirpasic/gods/trees/redblacktree"
+import "sort"
+
+// 我們從 i = x 開始陸續把 i - x 插入 sorted set
+// 然後開始找他的 upper bound & lower bound
+// 原實作透過第三方的紅黑樹來維護有序集合，但在無法存取
+// 外部模組的環境下會導致編譯失敗。這裡改以 slice
+// 加上 sort.SearchInts 來模擬有序集合即可。
 
 func minAbsoluteDifference(nums []int, x int) int {
-	rbt := redblacktree.NewWithIntComparator()
+	// 使用 slice 維護已插入的元素，透過 binary search 找到
+	// 與 nums[i] 最接近的前驅與後繼值
+	ordered := []int{}
 	ans := 1 << 30
 	for i := x; i < len(nums); i++ {
-		rbt.Put(nums[i-x], nil)
-		c, _ := rbt.Ceiling(nums[i])
-		f, _ := rbt.Floor(nums[i])
-		if c != nil {
-			ans = min(ans, c.Key.(int)-nums[i])
+		// 插入 nums[i-x]
+		pos := sort.SearchInts(ordered, nums[i-x])
+		ordered = append(ordered, 0)
+		copy(ordered[pos+1:], ordered[pos:])
+		ordered[pos] = nums[i-x]
+
+		// 找到第一個 >= nums[i]
+		pos = sort.SearchInts(ordered, nums[i])
+		if pos < len(ordered) {
+			ans = min(ans, ordered[pos]-nums[i])
 		}
-		if f != nil {
-			ans = min(ans, nums[i]-f.Key.(int))
+		if pos > 0 {
+			ans = min(ans, nums[i]-ordered[pos-1])
 		}
 	}
 	return ans

--- a/problems/2926_Maximum_Balanced_Subsequence_Sum/solution.go
+++ b/problems/2926_Maximum_Balanced_Subsequence_Sum/solution.go
@@ -1,8 +1,8 @@
 package _926_Maximum_Balanced_Subsequence_Sum
 
 import (
-	"github.com/emirpasic/gods/trees/redblacktree"
 	"math"
+	"sort"
 )
 
 func maxBalancedSubsequenceSum(nums []int) int64 {
@@ -12,37 +12,45 @@ func maxBalancedSubsequenceSum(nums []int) int64 {
 		arr[i] = nums[i] - i
 	}
 
-	rbt := redblacktree.NewWithIntComparator()
+	// pairs 以 arr 值遞增排序
+	type pair struct {
+		key int
+		val int64
+	}
+	var pairs []pair
 	var ret int64 = math.MinInt64
 
 	for i := 0; i < n; i++ {
 		x := arr[i]
-		node, found := rbt.Floor(x)
-		if found {
-			rbt.Put(x, max(int64(nums[i]), node.Value.(int64)+int64(nums[i])))
-		} else {
-			rbt.Put(x, int64(nums[i]))
+		// 找到 <= x 的最後一個元素
+		pos := sort.Search(len(pairs), func(j int) bool { return pairs[j].key > x })
+		cur := int64(nums[i])
+		if pos > 0 {
+			cur = max(cur, pairs[pos-1].val+int64(nums[i]))
 		}
-		temp, _ := rbt.Get(x)
-		if ret < temp.(int64) {
-			ret = temp.(int64)
-		}
-
-		// 使用迭代器來移除小於或等於當前值的元素
-		it := rbt.IteratorAt(rbt.GetNode(x))
-
-		var waitToRemove []int
-		for it.Next() {
-			if it.Value().(int64) <= temp.(int64) {
-				waitToRemove = append(waitToRemove, it.Key().(int))
-			} else {
-				break
+		// 插入或更新
+		if pos < len(pairs) && pairs[pos].key == x {
+			if cur > pairs[pos].val {
+				pairs[pos].val = cur
 			}
+		} else {
+			pairs = append(pairs, pair{})
+			copy(pairs[pos+1:], pairs[pos:])
+			pairs[pos] = pair{key: x, val: cur}
 		}
-		for _, v := range waitToRemove {
-			rbt.Remove(v)
+		// 移除後續 val 小於等於當前值的元素，保持遞減
+		idx := pos + 1
+		for idx < len(pairs) && pairs[idx].val <= cur {
+			idx++
+		}
+		if idx > pos+1 {
+			copy(pairs[pos+1:], pairs[idx:])
+			pairs = pairs[:len(pairs)-(idx-(pos+1))]
 		}
 
+		if ret < cur {
+			ret = cur
+		}
 	}
 
 	return ret

--- a/problems/2940_Find_Building_Where_Alice_and_Bob_Can_Meet/solution.go
+++ b/problems/2940_Find_Building_Where_Alice_and_Bob_Can_Meet/solution.go
@@ -6,10 +6,7 @@ package _940_Find_Building_Where_Alice_and_Bob_Can_Meet
 // in query[i] {a, b} 找到第一個heights[k] > max(heights[a], heights[b])
 // 所以從最右邊開始處理 然後把處理過的heights 放到有序容器裡面
 
-import (
-	"github.com/emirpasic/gods/trees/redblacktree"
-	"sort"
-)
+import "sort"
 
 func leftmostBuildingQueries(heights []int, queries [][]int) []int {
 	// 先確保for all {a, b} in query[i] a < b
@@ -22,19 +19,17 @@ func leftmostBuildingQueries(heights []int, queries [][]int) []int {
 	sort.Slice(queries, func(i, j int) bool {
 		return queries[i][1] > queries[j][1]
 	})
-	// 有序集合怎摸辦, 直接送一顆紅黑樹
-	rbt := redblacktree.NewWithIntComparator()
 	rets := make([]int, len(queries))
+	stack := []int{}
 	i := len(heights) - 1
-	//
 	for _, query := range queries {
 		a, b, idx := query[0], query[1], query[2]
-		// 將在b右邊的東西都擺進有序集合裡面惹
+		// 將在 b 右邊的元素加入單調遞減 stack
 		for i >= b {
-			for !rbt.Empty() && heights[i] >= rbt.Left().Key.(int) {
-				rbt.Remove(rbt.Left().Key)
+			for len(stack) > 0 && heights[i] >= heights[stack[len(stack)-1]] {
+				stack = stack[:len(stack)-1]
 			}
-			rbt.Put(heights[i], i)
+			stack = append(stack, i)
 			i--
 		}
 		if heights[a] < heights[b] || a == b {
@@ -42,14 +37,14 @@ func leftmostBuildingQueries(heights []int, queries [][]int) []int {
 			continue
 		}
 		target := max(heights[a], heights[b])
-		f, found := rbt.Ceiling(target + 1)
-		if found {
-			rets[idx] = f.Value.(int)
-			continue
+		ansIdx := -1
+		for j := len(stack) - 1; j >= 0; j-- {
+			if stack[j] > b && heights[stack[j]] > target {
+				ansIdx = stack[j]
+				break
+			}
 		}
-		rets[idx] = -1
-		// 如果找到的元素等於目標值，則尋找下一個元素
-
+		rets[idx] = ansIdx
 	}
 	return rets
 }


### PR DESCRIPTION
## Summary
- refactor Minimum Absolute Difference to avoid external tree dependency
- rewrite Find Building Where Alice and Bob Can Meet using local stack logic
- simplify Maximum Balanced Subsequence Sum without external library
- drop gods module from go.mod

## Testing
- `go vet ./problems/2817_Minimum_Absolute_Difference_Between_Elements_With_Constraint`
- `go test ./problems/2926_Maximum_Balanced_Subsequence_Sum`
- `go test ./problems/2940_Find_Building_Where_Alice_and_Bob_Can_Meet`
- `go test ./...` *(fails: TestValidSubarrays, TestMinimumSemesters, ...)*

------
https://chatgpt.com/codex/tasks/task_e_683fb4d0b29c832d93527deefc2a6786